### PR TITLE
stillBreakMsg check

### DIFF
--- a/src/main/java/com/dnyferguson/mineablespawners/listeners/BlockBreakListener.java
+++ b/src/main/java/com/dnyferguson/mineablespawners/listeners/BlockBreakListener.java
@@ -150,6 +150,9 @@ public class BlockBreakListener implements Listener {
             player.sendMessage(Chat.format(msg));
             return;
         }
-        player.sendMessage(Chat.format(stillBreakMsg));
+
+        if (stillBreakMsg.length() > 0) {
+            player.sendMessage(Chat.format(stillBreakMsg));
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MineableSpawners
-version: 2.0.8
+version: 2.0.9
 main: com.dnyferguson.mineablespawners.MineableSpawners
-authors: [fergydanny]
+authors: [fergydanny, kotas]
 description: A simplistic silk spawner plugin
 website: https://dnyferguson.com
 api-version: 1.13

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MineableSpawners
 version: 2.0.9
 main: com.dnyferguson.mineablespawners.MineableSpawners
-authors: [fergydanny, kotas]
+authors: [fergydanny]
 description: A simplistic silk spawner plugin
 website: https://dnyferguson.com
 api-version: 1.13


### PR DESCRIPTION
On server that I am working on, happened that `still-break-message` had empty string. Instead of skipping `sendMessage`, it sent blank line into chat (looks broken). Maybe all `sendMessage` actions should have sanity check if string, I am passing into it, is longer than 0? 

This also provide ability, to disable `still-break-message`.