### PR TITLE
Fixed NPE when putting a none existent player name

### DIFF
--- a/src/main/java/com/dnyferguson/mineablespawners/commands/GiveSubCommand.java
+++ b/src/main/java/com/dnyferguson/mineablespawners/commands/GiveSubCommand.java
@@ -19,7 +19,7 @@ public class GiveSubCommand {
 
     public void execute(MineableSpawners plugin, CommandSender sender, String target, String type, String amt) {
         Player targetPlayer = Bukkit.getPlayer(target);
-        if (target == null) {
+        if (target == null || targetPlayer == null) {
             plugin.getConfigurationHandler().sendMessage("give", "player-does-not-exist", sender);
             return;
         }


### PR DESCRIPTION
I fixed this as a member of my discord had an issue from my CrazyCrates plugin which caused an NPE in your plugin's give command.

Issue:
Seems you do check if `target` object is null but you forgot to check if the `targetPlayer` is null.

Original Error:
```
org.bukkit.event.EventException: null
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:320) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:529) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:514) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.PlayerConnection.a(PlayerConnection.java:2133) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.PacketPlayInWindowClick.a(SourceFile:33) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.PacketPlayInWindowClick.a(SourceFile:10) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.PlayerConnectionUtils.lambda$0(PlayerConnectionUtils.java:19) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.TickTask.run(SourceFile:18) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeTask(SourceFile:144) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.executeNext(SourceFile:118) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.MinecraftServer.aX(MinecraftServer.java:910) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.MinecraftServer.executeNext(MinecraftServer.java:903) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.IAsyncTaskHandler.awaitTasks(SourceFile:127) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.MinecraftServer.sleepForTick(MinecraftServer.java:887) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:820) [spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_111]
Caused by: org.bukkit.command.CommandException: Unhandled exception executing command 'ms' in plugin MineableSpawners v3.0.4
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:149) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.craftbukkit.v1_14_R1.CraftServer.dispatchCommand(CraftServer.java:710) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.Bukkit.dispatchCommand(Bukkit.java:627) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at me.badbones69.crazycrates.api.CrazyCrates.givePrize(CrazyCrates.java:794) ~[?:?]
	at me.badbones69.crazycrates.cratetypes.War.onInventoryClick(War.java:143) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_111]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_111]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_111]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_111]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:316) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	... 17 more
Caused by: java.lang.NullPointerException
	at com.dnyferguson.mineablespawners.commands.GiveSubCommand.execute(GiveSubCommand.java:43) ~[?:?]
	at com.dnyferguson.mineablespawners.commands.MineableSpawnersCommand.onCommand(MineableSpawnersCommand.java:42) ~[?:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:149) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.craftbukkit.v1_14_R1.CraftServer.dispatchCommand(CraftServer.java:710) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at org.bukkit.Bukkit.dispatchCommand(Bukkit.java:627) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
	at me.badbones69.crazycrates.api.CrazyCrates.givePrize(CrazyCrates.java:794) ~[?:?]
	at me.badbones69.crazycrates.cratetypes.War.onInventoryClick(War.java:143) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_111]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_111]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_111]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_111]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:316) ~[spigot-1.14.4.jar:git-Spigot-9de398a-9c887d4]
```


Fixed:
- Putting a player name that is not online causes an NPE.