### PR TITLE
Enabling Renaming of Spawners by checking Lore instead of the Name

### DIFF
--- a/plugin/src/main/java/com.dnyferguson.mineablespawners/api/API.java
+++ b/plugin/src/main/java/com.dnyferguson.mineablespawners/api/API.java
@@ -36,10 +36,6 @@ public class API {
 
     public EntityType getEntityTypeFromItemStack(ItemStack item) {
         EntityType entityType = null;
-
-
-        System.out.println(item.getItemMeta().getLore());
-        System.out.println(plugin.getConfigurationHandler().getList("global", "lore"));
         if(plugin.getConfigurationHandler().getBoolean("global", "lore-enabled")){
             try {
             return EntityType.valueOf(findInLore(item.getItemMeta().getLore()));

--- a/plugin/src/main/java/com.dnyferguson.mineablespawners/api/API.java
+++ b/plugin/src/main/java/com.dnyferguson.mineablespawners/api/API.java
@@ -3,6 +3,7 @@ package com.dnyferguson.mineablespawners.api;
 import com.cryptomorin.xseries.XMaterial;
 import com.dnyferguson.mineablespawners.MineableSpawners;
 import com.dnyferguson.mineablespawners.utils.Chat;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
@@ -19,8 +20,33 @@ public class API {
         this.plugin = plugin;
     }
 
+    private String findInLore(List<String> lore){
+        List<String> cLore = plugin.getConfigurationHandler().getList("global", "lore");
+        for(int i = 0; i< cLore.size(); i++){
+            String line = cLore.get(i);
+            if(line.contains("%mob%")){
+                String rest = line.replaceAll("&.", "");
+                String prefix = rest.split("%mob%")[0];
+                String suffix = rest.split("%mob%")[1];
+                return StringUtils.substringBetween(lore.get(i).replaceAll("§.", ""), prefix, suffix).toUpperCase();
+            }
+        }
+        return null;
+    }
+
     public EntityType getEntityTypeFromItemStack(ItemStack item) {
         EntityType entityType = null;
+
+
+        System.out.println(item.getItemMeta().getLore());
+        System.out.println(plugin.getConfigurationHandler().getList("global", "lore"));
+        if(plugin.getConfigurationHandler().getBoolean("global", "lore-enabled")){
+            try {
+            return EntityType.valueOf(findInLore(item.getItemMeta().getLore()));
+            } catch (Exception ignore) {
+                return null; //we shouldn't ingore this for security reasons
+            }
+        }
 
         // v1 compatibility
         try {


### PR DESCRIPTION
This update is for enabling renaming of Spawners, so therefore the lore is used instead of the DisplayName.