### PR TITLE
Fix spawner giving if block break is cancelled

### DIFF
--- a/src/main/java/com.dnyferguson.mineablespawners/listeners/SpawnerMineListener.java
+++ b/src/main/java/com.dnyferguson.mineablespawners/listeners/SpawnerMineListener.java
@@ -59,8 +59,12 @@ public class SpawnerMineListener implements Listener {
         }
     }
 
-    @EventHandler (priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler (priority = EventPriority.MONITOR)
     public void onSpawnerMine(BlockBreakEvent e) {
+        if (e.isCancelled()) {
+            return;
+        }
+
         // check if block is spawner
         Block block = e.getBlock();
         Material material = block.getType();


### PR DESCRIPTION
Plugin should not give a spawner if the player cannot break the block, this is causing duplication exploits with other plugins.