### PR TITLE
Update XSeries, item-nbt-api and Spigot Api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,16 @@
     </repositories>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.github.cryptomorin</groupId>
+            <artifactId>XSeries</artifactId>
+            <version>7.9.1.1</version>
+        </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.2-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -110,14 +116,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.cryptomorin</groupId>
-            <artifactId>XSeries</artifactId>
-            <version>7.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MineableSpawners
-version: 3.0.11
+version: 3.0.11.1
 main: com.dnyferguson.mineablespawners.MineableSpawners
 authors: [fergydanny]
 description: A simplistic silk spawner plugin


### PR DESCRIPTION
The plugin will not work unless item-nbt-api is up-to-date. This is a hotfix for that.
XSeries was also updated to better support other versions of minecraft.

Addressing issues #70  and #73 