### PR TITLE
NBT-API 1.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.11.3</version>
+            <version>2.12.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update NBT-API pom version.

Fixes 1.20.2 compatibility + also fixes ShopGUI+ crash if any shop contains minablespawners bridge item.

[MineableSpawners-3.1.5-1.20.2.zip](https://github.com/itsfergydanny/MineableSpawners/files/13367050/MineableSpawners-3.1.5-1.20.2.zip)

